### PR TITLE
Add precision/recall/F1 metrics

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,3 +9,4 @@ dependencies:
   - pip
   - pip:
     - flwr
+    - scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ torch
 torchvision
 numpy
 matplotlib
+scikit-learn

--- a/results_analyzer.py
+++ b/results_analyzer.py
@@ -82,8 +82,8 @@ class ResultsAnalyzer:
         output_path = Path(output_dir)
         output_path.mkdir(exist_ok=True)
         
-        # Filtra solo accuracy e loss per training
-        metrics_to_plot = ['accuracy', 'loss']
+        # Filtra le metriche principali
+        metrics_to_plot = ['accuracy', 'loss', 'precision', 'recall', 'f1']
         
         for dataset in self.df['dataset'].unique():
             for metric in metrics_to_plot:
@@ -265,7 +265,7 @@ class ResultsAnalyzer:
                 for round_num in run_data['round'].unique():
                     round_data = run_data[run_data['round'] == round_num]
                     
-                    for metric in ['accuracy', 'loss']:
+                    for metric in ['accuracy', 'loss', 'precision', 'recall', 'f1']:
                         metric_data = round_data[round_data['metric'] == metric]
                         
                         if len(metric_data) > 1:
@@ -293,7 +293,7 @@ class ResultsAnalyzer:
             fig.suptitle('Client Variance Evolution Over Rounds', fontsize=16)
             
             datasets = sorted(variance_df['dataset'].unique())
-            metrics = ['accuracy', 'loss']
+            metrics = ['accuracy', 'loss', 'precision', 'recall', 'f1']
             
             for i, dataset in enumerate(datasets):
                 for j, metric in enumerate(metrics):


### PR DESCRIPTION
## Summary
- compute precision, recall and F1 in client training and evaluation
- aggregate new metrics on the server and in experiment parsing
- update utils weighted_average and metric reporting
- extend results analyzer plotting to handle new metrics
- add scikit-learn dependency

## Testing
- `pip install scikit-learn`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683fff3742b4832a8f4cdc9a21a2bb3a