### PR TITLE
Fix attack parameter docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ python run_experiments.py --runner enhanced --test-mode --num-runs 2
 Run federated learning with adversarial attacks:
 
 ```bash
-python experiment_runners/run_with_attacks.py --strategy fedavg --model CNNNet --dataset cifar10 --attack_type label_flipping --malicious_clients 2
+python experiment_runners/run_with_attacks.py --strategy fedavg --dataset cifar10 --attack labelflip --labelflip-fraction 0.2
 ```
 
 ### Setup and Verification
@@ -630,46 +630,46 @@ python run_with_attacks.py [OPTIONS]
 #### Attack Parameters
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `--attack_type` | str | `None` | Type of attack to simulate |
-| `--malicious_clients` | int | `0` | Number of malicious clients |
-| `--attack_intensity` | float | `0.5` | Attack strength/intensity |
-| `--attack_rounds` | list | `[]` | Specific rounds for attacks |
+| `--attack` | str | `none` | Attack to run (`noise`, `missed`, `failure`, `asymmetry`, `labelflip`, `gradflip`, `all`) |
+| `--num-clients` | int | `10` | Number of clients to launch |
+| `--rounds` | int | `10` | Number of federation rounds |
 
 #### Attack-Specific Parameters
 
 **Label Flipping:**
 ```bash
---flip_probability 0.1      # Probability of label flip
---target_class 7            # Target class for flipping
+--labelflip-fraction 0.2    # Fraction of clients to attack
+--flip-prob 0.8             # Probability of label flip
+--source-class 0            # Optional fixed source class
+--target-class 7            # Optional fixed target class
 ```
 
 **Gradient Flipping:**
 ```bash
---flip_factor -1.0          # Gradient multiplication factor
+--gradflip-fraction 0.2     # Fraction of clients to attack
+--gradflip-intensity 1.0    # Intensity of gradient flip
 ```
 
 **Noise Injection:**
 ```bash
---noise_std 0.1             # Standard deviation of Gaussian noise
---noise_type gaussian       # Type of noise (gaussian, uniform)
+--noise-std 0.1             # Standard deviation of Gaussian noise
+--noise-fraction 0.3        # Fraction of clients to attack
 ```
 
 **Data Asymmetry:**
 ```bash
---asymmetry_factor 0.8      # Level of data asymmetry
---missing_classes [0,1,2]   # Classes to exclude from clients
+--asymmetry-min 0.5         # Minimum asymmetry factor
+--asymmetry-max 3.0         # Maximum asymmetry factor
 ```
 
 **Client Failure:**
 ```bash
---failure_probability 0.1   # Probability of client failure
---failure_type random       # Type of failure (random, targeted)
+--failure-prob 0.2          # Probability of client failure
 ```
 
 **Missed Class:**
 ```bash
---excluded_classes [9]      # Classes to exclude from specific clients
---affected_clients [0,1]    # Clients affected by missing classes
+--missed-prob 0.3           # Probability that a class is missed
 ```
 
 ## Aggregation Strategies
@@ -908,59 +908,58 @@ The framework includes 6 different attack types for security research:
 ### 1. **Label Flipping Attack**
 - **File:** `attacks/label_flipping.py`
 - **Description:** Malicious clients flip labels of training data
-- **Usage:** `--attack_type label_flipping --flip_probability 0.1 --target_class 7`
+- **Usage:** `--attack labelflip --labelflip-fraction 0.2 --flip-prob 0.8`
 - **Parameters:**
-  - `flip_probability`: Probability of flipping a label (0.0-1.0)
-  - `target_class`: Target class for directed attacks (optional)
+  - `labelflip-fraction`: Fraction of clients to attack
+  - `flip-prob`: Probability of flipping a label
+  - `source-class`/`target-class`: Optional fixed classes
 - **Impact:** Degrades model accuracy on specific classes
 - **Detection:** Monitor per-class accuracy degradation
 
 ### 2. **Gradient Flipping Attack**
 - **File:** `attacks/gradient_flipping.py`
 - **Description:** Malicious clients send inverted gradients
-- **Usage:** `--attack_type gradient_flipping --flip_factor -1.0`
+- **Usage:** `--attack gradflip --gradflip-fraction 0.2 --gradflip-intensity 1.0`
 - **Parameters:**
-  - `flip_factor`: Multiplication factor for gradients (negative values flip)
+  - `gradflip-fraction`: Fraction of clients to attack
+  - `gradflip-intensity`: Multiplication factor for gradients (1.0 flips)
 - **Impact:** Severely disrupts convergence
 - **Detection:** Monitor gradient norms and directions
 
 ### 3. **Noise Injection Attack**
 - **File:** `attacks/noise_injection.py`
 - **Description:** Adds random noise to client updates
-- **Usage:** `--attack_type noise_injection --noise_std 0.1 --noise_type gaussian`
+- **Usage:** `--attack noise --noise-std 0.1 --noise-fraction 0.3`
 - **Parameters:**
-  - `noise_std`: Standard deviation of noise
-  - `noise_type`: Type of noise (gaussian, uniform, laplacian)
+  - `noise-std`: Standard deviation of the noise
+  - `noise-fraction`: Fraction of clients to attack
 - **Impact:** Slows convergence, reduces final accuracy
 - **Detection:** Statistical analysis of update distributions
 
 ### 4. **Data Asymmetry Attack**
 - **File:** `attacks/data_asymmetry.py`
 - **Description:** Creates extreme data heterogeneity
-- **Usage:** `--attack_type data_asymmetry --asymmetry_factor 0.8`
+- **Usage:** `--attack asymmetry --asymmetry-min 0.5 --asymmetry-max 3.0`
 - **Parameters:**
-  - `asymmetry_factor`: Level of data skewness (0.0-1.0)
-  - `missing_classes`: Specific classes to exclude
+  - `asymmetry-min/asymmetry-max`: Range of asymmetry factors
 - **Impact:** Biases global model toward specific classes
 - **Detection:** Monitor class distribution across clients
 
 ### 5. **Client Failure Attack**
 - **File:** `attacks/client_failure.py`
 - **Description:** Simulates client dropouts and failures
-- **Usage:** `--attack_type client_failure --failure_probability 0.1 --failure_type random`
+- **Usage:** `--attack failure --failure-prob 0.2`
 - **Parameters:**
-  - `failure_probability`: Probability of client failure per round
-  - `failure_type`: Pattern of failures (random, targeted, gradual)
+  - `failure-prob`: Probability of client failure per round
 - **Impact:** Reduces available data for training
 - **Detection:** Monitor client participation rates
 
 ### 6. **Missed Class Attack**
 - **File:** `attacks/missed_class.py`
 - **Description:** Specific clients never see certain classes
-- **Usage:** `--attack_type missed_class --excluded_classes [9] --affected_clients [0,1]`
+- **Usage:** `--attack missed --missed-prob 0.3`
 - **Parameters:**
-  - `excluded_classes`: List of classes to exclude
-  - `affected_clients`: List of client IDs to affect
+  - `missed-prob`: Probability that a client misses a class
 - **Impact:** Creates systematic bias in learning
 - **Detection:** Analyze per-client class distributions
 
@@ -1199,7 +1198,7 @@ Use the built-in parameter sweeps:
 python server.py --strategy fedavg --learning_rate 0.001,0.01,0.1
 
 # Test multiple strategies
-python run_with_attacks.py --strategy fedavg,fedprox,scaffold --attack_type label_flipping
+python run_with_attacks.py --strategy fedavg,fedprox,scaffold --attack labelflip
 ```
 
 ### Logging and Monitoring


### PR DESCRIPTION
## Summary
- fix attack-specific CLI parameters in README
- clarify usage examples for attack runner

## Testing
- `python tests/run_tests.py` *(fails: SyntaxError in run_tests.py)*

------
https://chatgpt.com/codex/tasks/task_e_6840d7997b78832a934e103441084bb8