### PR TITLE
Fix test runner import and add custom exceptions

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -11,6 +11,7 @@ import unittest
 import time
 from pathlib import Path
 import argparse
+import importlib
 
 # Add the project root to the path
 project_root = Path(__file__).parent.parent
@@ -149,11 +150,16 @@ def run_specific_test(test_name):
             # Test method specified
             suite.addTest(loader.loadTestsFromName(test_name))
         else:
-            # Test class specified - try to find it
-            from tests.test_enhanced_experiment_runner import *
-            from tests.test_checkpoint_system import *
-            
-            test_class = globals().get(test_name)
+            # Test class specified - try to find it dynamically
+            enhanced_module = importlib.import_module(
+                'tests.test_enhanced_experiment_runner')
+            checkpoint_module = importlib.import_module(
+                'tests.test_checkpoint_system')
+
+            test_class = getattr(enhanced_module, test_name, None)
+            if test_class is None:
+                test_class = getattr(checkpoint_module, test_name, None)
+
             if test_class:
                 tests = loader.loadTestsFromTestCase(test_class)
                 suite.addTests(tests)


### PR DESCRIPTION
## Summary
- fix dynamic loader in tests so that wildcard imports aren't used in a function
- add missing exception classes in `enhanced_experiment_runner`
- raise `ResourceError` when ports are exhausted
- map validation errors to new `ExperimentValidationError`

## Testing
- `python tests/run_tests.py --quick` *(fails: EnhancedExperimentRunner.__init__() got an unexpected keyword argument 'config_file')*

------
https://chatgpt.com/codex/tasks/task_e_6840d704ca0c832a828ce357b1a2ef7b