### PR TITLE
Improve weighted_average handling for empty inputs

### DIFF
--- a/utilities/tests/test_utils.py
+++ b/utilities/tests/test_utils.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, ROOT_DIR)
+
+import utilities.utils as utils
+
+
+def test_weighted_average_empty_metrics():
+    assert utils.weighted_average([]) == {}
+
+
+def test_weighted_average_zero_examples():
+    metrics = [(0, {"accuracy": 0.5}), (0, {"accuracy": 1.0})]
+    assert utils.weighted_average(metrics) == {}
+
+
+def test_weighted_average_normal_case():
+    metrics = [(2, {"acc": 0.5}), (8, {"acc": 0.75})]
+    result = utils.weighted_average(metrics)
+    expected = {"acc": (2 * 0.5 + 8 * 0.75) / 10}
+    assert result == expected

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -99,8 +99,16 @@ def aggregate_ndarrays_weighted(weights: List[List[np.ndarray]], normalization_f
 # Function to calculate weighted average of metrics
 def weighted_average(metrics: List[Tuple[int, Dict[str, Scalar]]]) -> Dict[str, Scalar]:
     """Compute weighted average for an arbitrary set of metrics."""
+    if not metrics:
+        logger.warning("No metrics provided to weighted_average")
+        return {}
+
     examples = [num_examples for num_examples, _ in metrics]
     total_examples = sum(examples)
+
+    if total_examples == 0:
+        logger.warning("Total number of examples is zero in weighted_average")
+        return {}
 
     aggregated: Dict[str, Scalar] = {}
     all_keys = set().union(*(m.keys() for _, m in metrics))


### PR DESCRIPTION
## Summary
- handle empty metrics in `weighted_average`
- warn and return empty metrics when number of examples is zero
- add unit tests covering empty metrics and zero-example cases

## Testing
- `pytest utilities/tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f68411f30832a8488ee92a9da2ca8