### PR TITLE
Remove unused imports from config and strategy

### DIFF
--- a/configuration/config_manager.py
+++ b/configuration/config_manager.py
@@ -9,7 +9,6 @@ import logging
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Dict, Any, Optional, List
-import os
 
 logger = logging.getLogger(__name__)
 

--- a/strategy/baseline_wrappers.py
+++ b/strategy/baseline_wrappers.py
@@ -13,10 +13,13 @@ from typing import Dict, List, Optional, Tuple, Union, Any, Type, Callable
 from flwr.common.typing import NDArrays
 from flwr.server.client_proxy import ClientProxy
 from flwr.common import FitRes, EvaluateRes
-import numpy as np
-from utilities.utils import BaseStrategy, parameters_to_ndarrays, ndarrays_to_parameters, aggregate_ndarrays_weighted, logger
-import sys
-import os
+from utilities.utils import (
+    BaseStrategy,
+    parameters_to_ndarrays,
+    ndarrays_to_parameters,
+    aggregate_ndarrays_weighted,
+    logger,
+)
 
 # Correct type for evaluate_fn
 EvaluateFnType = Callable[[int, NDArrays, Dict[str, Scalar]], Optional[Tuple[float, Dict[str, Scalar]]]]


### PR DESCRIPTION
## Summary
- drop `os` import from `config_manager`
- drop unused imports from `baseline_wrappers`
- run flake8 and py_compile to ensure no references remain

## Testing
- `flake8 configuration/config_manager.py strategy/baseline_wrappers.py`
- `python -m py_compile configuration/config_manager.py strategy/baseline_wrappers.py`

------
https://chatgpt.com/codex/tasks/task_e_684f68736b0c832a89d425933fb83423