### PR TITLE
Make client count configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ python experiment_runners/enhanced_experiment_runner.py --test-mode
 Run federated learning with adversarial attacks:
 
 ```bash
-python experiment_runners/run_with_attacks.py --strategy fedavg --dataset cifar10 --attack labelflip --labelflip-fraction 0.2
+python experiment_runners/run_with_attacks.py --strategy fedavg --dataset cifar10 \
+    --attack labelflip --labelflip-fraction 0.2 --num-clients 10
 ```
 
 ### Setup and Verification

--- a/experiment_runners/run_with_attacks.py
+++ b/experiment_runners/run_with_attacks.py
@@ -287,7 +287,7 @@ def main():
         client_path = current_dir / "core" / "client.py"
     
     for i in range(args.num_clients):
-        cmd = [sys.executable, str(client_path), "--cid", str(i)]
+        cmd = [sys.executable, str(client_path), "--cid", str(i), "--num-clients", str(args.num_clients)]
         
         # Aggiungi il dataset se diverso dal default
         if args.dataset != "MNIST":

--- a/tests/test_attack_client_selection.py
+++ b/tests/test_attack_client_selection.py
@@ -1,0 +1,29 @@
+import numpy as np
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from attacks.label_flipping import select_clients_for_label_flipping
+from attacks.noise_injection import select_clients_for_noise_injection
+
+
+def test_label_flipping_selection():
+    np.random.seed(0)
+    clients = select_clients_for_label_flipping(5, 0.4)
+    assert len(clients) == 2
+    assert all(0 <= c < 5 for c in clients)
+
+
+def test_noise_injection_selection():
+    np.random.seed(1)
+    clients = select_clients_for_noise_injection(8, 0.25)
+    assert len(clients) == 2
+    assert all(0 <= c < 8 for c in clients)
+
+
+def test_zero_fraction_returns_empty():
+    np.random.seed(0)
+    assert select_clients_for_label_flipping(6, 0.0) == []
+    assert select_clients_for_noise_injection(6, 0.0) == []


### PR DESCRIPTION
## Summary
- read `num_clients` from config when starting clients
- pass this value through `run_with_attacks.py`
- update docs with new argument
- test client selection helpers

## Testing
- `pytest -q tests/test_attack_client_selection.py`

------
https://chatgpt.com/codex/tasks/task_e_684f68663b40832ab1ed398be526fd9d