### PR TITLE
Fix weighted array aggregation

### DIFF
--- a/utilities/tests/test_utils.py
+++ b/utilities/tests/test_utils.py
@@ -4,6 +4,8 @@ import sys
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.insert(0, ROOT_DIR)
 
+import numpy as np
+
 import utilities.utils as utils
 
 
@@ -21,3 +23,19 @@ def test_weighted_average_normal_case():
     result = utils.weighted_average(metrics)
     expected = {"acc": (2 * 0.5 + 8 * 0.75) / 10}
     assert result == expected
+
+
+def test_aggregate_ndarrays_weighted_normalization():
+    weights = [[np.array([1.0])], [np.array([3.0])]]
+    factors = [1.0, 3.0]
+    result = utils.aggregate_ndarrays_weighted(weights, factors)
+    expected = [np.array([1.0]) * 0.25 + np.array([3.0]) * 0.75]
+    assert len(result) == 1
+    assert np.allclose(result[0], expected[0])
+
+
+def test_aggregate_ndarrays_weighted_negative_factor():
+    weights = [[np.array([1.0])]]
+    factors = [-1.0]
+    result = utils.aggregate_ndarrays_weighted(weights, factors)
+    assert result == []

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -73,6 +73,18 @@ def aggregate_ndarrays_weighted(weights: List[List[np.ndarray]], normalization_f
         if not weights or not normalization_factors or len(weights) != len(normalization_factors):
             logger.error("Invalid inputs to aggregate_ndarrays_weighted")
             return []
+
+        # Ensure all normalization factors are non-negative
+        if not all(f >= 0 for f in normalization_factors):
+            logger.error("Normalization factors must be non-negative")
+            return []
+
+        # Normalize factors so that they sum to 1
+        total_factor = sum(normalization_factors)
+        if total_factor <= 0:
+            logger.error("Sum of normalization factors must be positive")
+            return []
+        normalization_factors = [f / total_factor for f in normalization_factors]
         
         # Create a list of empty ndarrays, one for each layer
         aggregated_ndarrays = [


### PR DESCRIPTION
## Summary
- validate non-negative weights in `aggregate_ndarrays_weighted`
- normalize weight factors to sum to 1
- test with non-normalized and negative weights

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: flwr_baselines and dasha)*
- `pytest utilities/tests/test_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6dcc6bd8832a8232150270c56e84