### PR TITLE
Add unit tests for utilities and data asymmetry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scikit-learn
 psutil
 omegaconf
 pyhamcrest
+pytest

--- a/tests/test_checkpoint_manager.py
+++ b/tests/test_checkpoint_manager.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from utilities.checkpoint_manager import CheckpointManager
+
+
+def test_register_and_complete_runs(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    config = {"strategy": "fedavg", "attack": "none", "dataset": "mnist"}
+    manager.register_experiments([config], num_runs=2)
+    exp_id = "fedavg_none_mnist"
+    assert exp_id in manager.experiment_status
+    manager.mark_run_completed(exp_id, 0)
+    manager.mark_run_completed(exp_id, 1)
+    status = manager.experiment_status[exp_id]
+    assert status.is_complete()
+    assert status.success is True
+
+    manager2 = CheckpointManager(tmp_path)
+    assert manager2.experiment_status[exp_id].completed_runs == {0, 1}
+
+
+def test_backup_results(tmp_path):
+    manager = CheckpointManager(tmp_path)
+    df = pd.DataFrame({"a": [1, 2]})
+    manager.backup_results(df, "_test")
+    backups = list((tmp_path / "results_backup").glob("results_backup_*_test.csv"))
+    assert backups

--- a/tests/test_data_asymmetry.py
+++ b/tests/test_data_asymmetry.py
@@ -1,0 +1,46 @@
+import sys
+import numpy as np
+from pathlib import Path
+from torch.utils.data import Dataset
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from attacks.data_asymmetry import generate_client_sizes, create_asymmetric_datasets
+
+
+class DummyDataset(Dataset):
+    def __init__(self, n):
+        self.data = list(range(n))
+        self.targets = [i % 10 for i in range(n)]
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+
+def test_generate_client_sizes_uniform():
+    sizes = generate_client_sizes(10, 3, 1.0, 1.0)
+    assert sum(sizes) == 10
+    assert len(sizes) == 3
+    assert max(sizes) - min(sizes) <= 1
+
+
+def test_generate_client_sizes_zero_handling():
+    np.random.seed(0)
+    sizes = generate_client_sizes(5, 10, 0.1, 0.1)
+    assert sum(sizes) == 5
+    assert len(sizes) == 10
+    assert all(s in (0, 1) for s in sizes)
+
+
+def test_create_asymmetric_datasets(tmp_path):
+    np.random.seed(1)
+    dataset = DummyDataset(20)
+    client_sizes = [5, 5, 10]
+    dsets, removed = create_asymmetric_datasets(dataset, client_sizes, class_removal_prob=0.5)
+    assert len(dsets) == 3
+    assert sum(len(d.indices) for d in dsets) <= len(dataset)
+    assert set(removed.keys()) <= {0, 1, 2}

--- a/tests/test_port_manager.py
+++ b/tests/test_port_manager.py
@@ -1,0 +1,38 @@
+import sys
+import socket
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from experiment_runners.enhanced_experiment_runner import PortManager, ResourceError
+
+
+def test_acquire_and_release_port():
+    pm = PortManager(base_port=15000, num_ports=2)
+    p1 = pm.acquire_port()
+    p2 = pm.acquire_port()
+    assert {p1, p2} == {15000, 15001}
+    with pytest.raises(ResourceError):
+        pm.acquire_port()
+    pm.release_port(p1)
+    assert pm.acquire_port() == p1
+
+
+def test_port_context_manager():
+    pm = PortManager(base_port=16000, num_ports=1)
+    with pm.get_port() as p:
+        assert p == 16000
+        assert pm.available_ports == []
+    assert pm.available_ports == [16000]
+
+
+def test_is_port_free():
+    pm = PortManager(base_port=17000, num_ports=1)
+    s = socket.socket()
+    s.bind(("localhost", 0))
+    port = s.getsockname()[1]
+    assert pm.is_port_free(port) is False
+    s.close()
+    assert pm.is_port_free(port) is True

--- a/tests/test_retry_manager.py
+++ b/tests/test_retry_manager.py
@@ -1,0 +1,50 @@
+import sys
+import time
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from utilities.retry_manager import RetryManager, RetryConfig, FailureType
+
+
+def test_classify_failure():
+    manager = RetryManager()
+    assert manager.classify_failure("timeout error") == FailureType.TIMEOUT
+    assert manager.classify_failure("permission denied") == FailureType.PERMISSION_ERROR
+    assert manager.classify_failure("connection lost") == FailureType.NETWORK_ERROR
+    assert manager.classify_failure("memory issue") == FailureType.RESOURCE_ERROR
+    assert manager.classify_failure("process failed", return_code=1) == FailureType.PROCESS_ERROR
+    assert manager.classify_failure("something unknown") == FailureType.UNKNOWN_ERROR
+
+
+def test_execute_with_retry_success(monkeypatch):
+    calls = {"count": 0}
+
+    def func():
+        calls["count"] += 1
+        if calls["count"] < 3:
+            return False, "timeout"
+        return True, "ok"
+
+    cfg = RetryConfig(max_retries=3, base_delay=0, exponential_backoff=False)
+    manager = RetryManager(cfg)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    success, out = manager.execute_with_retry("exp", func)
+    assert success is True
+    assert out == "ok"
+    assert calls["count"] == 3
+    assert len(manager.failure_history["exp"]) == 2
+
+
+def test_execute_with_non_retryable(monkeypatch):
+    def func():
+        return False, "process failed"
+
+    cfg = RetryConfig(max_retries=2, retry_on_types={FailureType.TIMEOUT})
+    manager = RetryManager(cfg)
+    monkeypatch.setattr(time, "sleep", lambda x: None)
+    success, out = manager.execute_with_retry("exp2", func)
+    assert success is False
+    assert len(manager.failure_history["exp2"]) == 1


### PR DESCRIPTION
## Summary
- add PortManager tests
- add CheckpointManager tests
- add RetryManager tests
- add data asymmetry function tests
- include pytest in `requirements.txt`

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6db43450832a867d02f2bab07cc1