### PR TITLE
Fix log parsing for signed and exponential numbers

### DIFF
--- a/experiment_runners/stable_experiment_runner.py
+++ b/experiment_runners/stable_experiment_runner.py
@@ -96,15 +96,16 @@ class MetricsCollector:
     
     def parse_client_log(self, log_line: str, client_id: int, run_id: int) -> Optional[Dict]:
         """Estrae metriche dai log del client."""
+        num = r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?"
         patterns = [
             # Pattern per fit metrics
-            r'fit complete.*avg_loss=([0-9.]+).*accuracy=([0-9.]+)',
-            # Pattern per evaluate metrics  
-            r'evaluate complete.*avg_loss=([0-9.]+).*accuracy=([0-9.]+)',
+            rf'fit complete.*avg_loss=({num}).*accuracy=({num})',
+            # Pattern per evaluate metrics
+            rf'evaluate complete.*avg_loss=({num}).*accuracy=({num})',
             # Pattern per training metrics durante il fit
-            r'Training batch.*loss=([0-9.]+).*acc=([0-9.]+)',
+            rf'Training batch.*loss=({num}).*acc=({num})',
             # Pattern per evaluation metrics durante evaluate
-            r'Eval batch.*loss=([0-9.]+).*acc=([0-9.]+)'
+            rf'Eval batch.*loss=({num}).*acc=({num})'
         ]
         
         for pattern in patterns:
@@ -139,11 +140,12 @@ class MetricsCollector:
     def parse_server_log(self, log_line: str, run_id: int) -> Optional[Dict]:
         """Estrae metriche dai log del server."""
         # Pattern per metriche aggregate del server
+        num = r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?"
         patterns = [
-            r'Round (\d+).*aggr.*accuracy.*([0-9.]+)',
-            r'Round (\d+).*aggregated.*loss.*([0-9.]+)',
-            r'evaluate.*Round (\d+).*accuracy.*([0-9.]+)',
-            r'fit.*Round (\d+).*loss.*([0-9.]+)'
+            rf'Round (\d+).*aggr.*accuracy.*?({num})',
+            rf'Round (\d+).*aggregated.*loss.*?({num})',
+            rf'evaluate.*Round (\d+).*accuracy.*?({num})',
+            rf'fit.*Round (\d+).*loss.*?({num})'
         ]
         
         for pattern in patterns:

--- a/tests/test_log_parsing.py
+++ b/tests/test_log_parsing.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+import math
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from experiment_runners.stable_experiment_runner import MetricsCollector
+
+
+def test_parse_client_log_supports_sign_and_exponent():
+    collector = MetricsCollector()
+    line = (
+        "[Client 1] fit complete | avg_loss=-1.23e-2, accuracy=+9.87e-01 Round 3"
+    )
+    res = collector.parse_client_log(line, client_id=1, run_id=0)
+    assert res is not None
+    assert res["client_id"] == 1
+    assert res["run"] == 0
+    assert res["round"] == 3
+    assert res["metric_type"] == "training"
+    assert math.isclose(res["loss"], -1.23e-2)
+    assert math.isclose(res["accuracy"], 9.87e-01)
+
+
+def test_parse_server_log_supports_sign_and_exponent():
+    collector = MetricsCollector()
+    line = "evaluate server Round 2 accuracy -5.5e-01"
+    res = collector.parse_server_log(line, run_id=1)
+    assert res is not None
+    assert res["run"] == 1
+    assert res["round"] == 2
+    assert res["metric"] == "accuracy"
+    assert res["phase"] == "evaluation"
+    assert math.isclose(res["value"], -5.5e-01)


### PR DESCRIPTION
## Summary
- update regexes in `MetricsCollector` of stable runner to handle sign and exponent notation
- add tests for new log parsing behaviour

## Testing
- `pytest tests utilities/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6dabc4f4832a9faa4fcec4d971a5