### PR TITLE
Fix cpu usage sampling delay

### DIFF
--- a/configuration/config_manager.py
+++ b/configuration/config_manager.py
@@ -245,7 +245,8 @@ class ConfigManager:
             checks["memory_available"] = available_memory_mb >= self.resources.max_memory_mb / 2
             
             # Controlla CPU
-            cpu_percent = psutil.cpu_percent(interval=1)
+            # Usa interval=None per evitare ritardi dovuti al campionamento
+            cpu_percent = psutil.cpu_percent(interval=None)
             checks["cpu_available"] = cpu_percent < self.resources.max_cpu_percent
             
             # Controlla spazio disco

--- a/tests/test_config_manager_performance.py
+++ b/tests/test_config_manager_performance.py
@@ -1,0 +1,10 @@
+import time
+from configuration.config_manager import ConfigManager
+
+def test_check_system_resources_fast():
+    cm = ConfigManager()
+    start = time.perf_counter()
+    cm.check_system_resources()
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0
+


### PR DESCRIPTION
## Summary
- use non-blocking `cpu_percent` call in the config manager
- add a quick performance regression test for `check_system_resources`

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6dfb4e44832a846b8cd364bfb1dd