### PR TITLE
Ensure process cleanup on timeouts

### DIFF
--- a/experiment_runners/basic_experiment_runner.py
+++ b/experiment_runners/basic_experiment_runner.py
@@ -384,7 +384,12 @@ class ExperimentRunner:
             logger.error(
                 f"Experiment {experiment_id}, run {run_id} timed out after {self.process_timeout} seconds"
             )
-            process.kill()            # Log ultimi 10 righe di output per debug
+            process.kill()
+            try:
+                process.wait(timeout=5)
+            except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+                pass
+            # Log ultimi 10 righe di output per debug
             if output_lines:
                 logger.error("Last 10 lines before timeout:")
                 for line in list(output_lines)[-10:]:

--- a/experiment_runners/enhanced_experiment_runner.py
+++ b/experiment_runners/enhanced_experiment_runner.py
@@ -804,6 +804,10 @@ class EnhancedExperimentRunner:
                 
             except subprocess.TimeoutExpired:
                 process.kill()
+                try:
+                    process.wait(timeout=5)
+                except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+                    pass
                 output_lines.append("Process timed out")
                 success = False
             finally:

--- a/experiment_runners/run_extensive_experiments.py
+++ b/experiment_runners/run_extensive_experiments.py
@@ -121,6 +121,10 @@ class ExtensiveExperimentRunner(EnhancedExperimentRunner):
                 success = return_code == 0
             except subprocess.TimeoutExpired:
                 process.kill()
+                try:
+                    process.wait(timeout=5)
+                except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+                    pass
                 output_lines.append("Process timed out")
                 success = False
             finally:

--- a/experiment_runners/stable_experiment_runner.py
+++ b/experiment_runners/stable_experiment_runner.py
@@ -378,6 +378,10 @@ class ExperimentRunner:
                     f"Experiment {experiment_id}, run {run_id} timed out after {self.process_timeout} seconds"
                 )
                 process.kill()
+                try:
+                    process.wait(timeout=5)
+                except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+                    pass
                 # Log ultimi 10 righe di output per debug
                 if output_lines:
                     logger.error("Last 10 lines before timeout:")

--- a/tests/test_process_cleanup.py
+++ b/tests/test_process_cleanup.py
@@ -1,0 +1,70 @@
+import subprocess
+import sys
+from pathlib import Path
+import types
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from experiment_runners.basic_experiment_runner import ExperimentConfig, ExperimentRunner
+
+class DummyProc:
+    def __init__(self):
+        self.stdout = self
+        self.killed = False
+        self.wait_after_kill_called = False
+        self.initial_wait_called = False
+        self.iter = 0
+        self.pid = 12345
+
+    # file-like interface for stdout
+    def readline(self):
+        self.iter += 1
+        if self.iter > 2:
+            self.stdout = None
+            return ""
+        return "line\n"
+
+    def poll(self):
+        return None
+
+    def wait(self, timeout=None):
+        if not self.killed:
+            self.initial_wait_called = True
+            raise subprocess.TimeoutExpired(cmd="dummy", timeout=timeout)
+        else:
+            self.wait_after_kill_called = True
+            return 0
+
+    def kill(self):
+        self.killed = True
+
+    def close(self):
+        pass
+
+class DummyRunner(ExperimentRunner):
+    def kill_flower_processes(self):
+        pass
+
+    def wait_for_port(self, port: int, timeout: int = 60):
+        pass
+
+    def parse_and_store_metrics(self, log_line, config, run_id):
+        pass
+
+    def build_attack_command(self, config):
+        return [sys.executable, "-c", "pass"]
+
+def test_process_terminated_on_timeout(monkeypatch):
+    dummy = DummyProc()
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: dummy)
+
+    cfg = ExperimentConfig(strategy="fedavg", attack="none", dataset="MNIST")
+    runner = DummyRunner(base_dir=".", results_dir="./tmp", process_timeout=1)
+
+    success = runner.run_single_experiment(cfg, run_id=0)
+    assert not success
+    assert dummy.killed
+    assert dummy.wait_after_kill_called


### PR DESCRIPTION
## Summary
- close processes properly on timeout in all experiment runners
- test that a stuck process is killed and waited on

## Testing
- `pytest tests/test_process_cleanup.py tests/test_attack_client_selection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6ddb5580832aae3eecdbd9e053bf