### PR TITLE
Refactor attack config handling

### DIFF
--- a/configuration/attack_config.py
+++ b/configuration/attack_config.py
@@ -1,61 +1,74 @@
+"""Configuration for federated learning attacks.
+
+This module defines a small data structure holding default attack
+parameters.  A factory function returns a new instance each time so
+that modifications do not affect other modules.
 """
-Configurazione per gli attacchi di Federated Learning.
-Questo file contiene tutti i parametri di configurazione per i vari tipi di attacchi.
-"""
+from dataclasses import dataclass, field
+from typing import Any, Dict, Set
 
-# Configurazione generale
-ENABLE_ATTACKS = True  # Abilita/disabilita globalmente tutti gli attacchi
 
-# 1. Noise Injection
-NOISE_INJECTION = {
-    "enabled": False,  # Abilita/disabilita questo tipo di attacco
-    "noise_std": 0.1,  # Deviazione standard del rumore gaussiano
-    "attack_fraction": 0.2,  # Frazione di client da attaccare (0.0-1.0)
-}
+@dataclass
+class AttackConfig:
+    """Container for attack settings."""
 
-# 2. Missed Class
-MISSED_CLASS = {
-    "enabled": False,  # Abilita/disabilita questo tipo di attacco
-    "class_removal_prob": 0.3,  # Probabilità che un client sia soggetto a rimozione di classe
-}
+    enable_attacks: bool = True
+    noise_injection: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": False,
+            "noise_std": 0.1,
+            "attack_fraction": 0.2,
+        }
+    )
+    missed_class: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": False,
+            "class_removal_prob": 0.3,
+        }
+    )
+    client_failure: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": False,
+            "failure_prob": 0.1,
+            "debug_mode": True,
+        }
+    )
+    data_asymmetry: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": False,
+            "min_factor": 0.5,
+            "max_factor": 3.0,
+            "class_removal_prob": 0.0,
+        }
+    )
+    label_flipping: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": False,
+            "attack_fraction": 0.2,
+            "flip_probability": 0.8,
+            "fixed_source": None,
+            "fixed_target": None,
+            "change_each_round": True,
+        }
+    )
+    gradient_flipping: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "enabled": False,
+            "attack_fraction": 0.2,
+            "flip_intensity": 1.0,
+        }
+    )
+    attack_state: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "client_failure_history": {},
+            "source_target_history": {},
+            "current_round": 0,
+            "broken_clients_in_current_round": set(),
+            "gradient_flipping_history": {},
+        }
+    )
 
-# 3. Client Failure
-CLIENT_FAILURE = {
-    "enabled": False,  # Abilita/disabilita questo tipo di attacco
-    "failure_prob": 0.1,  # Probabilità che un client fallisca in un round specifico
-    "debug_mode": True,  # Se True, stampa informazioni aggiuntive di debug
-}
 
-# 4. Data Asymmetry
-DATA_ASYMMETRY = {
-    "enabled": False,  # Abilita/disabilita questo tipo di attacco
-    "min_factor": 0.5,  # Fattore minimo per la distribuzione uniforme
-    "max_factor": 3.0,  # Fattore massimo per la distribuzione uniforme
-    "class_removal_prob": 0.0,  # Probabilità che un client sia soggetto a rimozione di classe
-}
-
-# 5. Targeted Label-flipping Attack
-LABEL_FLIPPING = {
-    "enabled": False,  # Abilita/disabilita questo tipo di attacco
-    "attack_fraction": 0.2,  # Frazione di client da attaccare (0.0-1.0)
-    "flip_probability": 0.8,  # Probabilità che un'etichetta della classe sorgente venga cambiata
-    "fixed_source": None,  # Classe sorgente fissa (None per casuale)
-    "fixed_target": None,  # Classe target fissa (None per casuale)
-    "change_each_round": True,  # Se True, cambia le classi sorgente/target ad ogni round
-}
-
-# 6. Gradient Flipping Attack
-GRADIENT_FLIPPING = {
-    "enabled": False,  # Abilita/disabilita questo tipo di attacco
-    "attack_fraction": 0.2,  # Frazione di client da attaccare (0.0-1.0)
-    "flip_intensity": 1.0,  # Intensità dell'attacco (1.0 = flip completo, 0.5 = flip parziale)
-}
-
-# Registro dello stato degli attacchi (utile per tracking tra round)
-ATTACK_STATE = {
-    "client_failure_history": {},  # Storico dei fallimenti dei client
-    "source_target_history": {},  # Storico delle classi sorgente/target per round
-    "current_round": 0,  # Round corrente di federazione
-    "broken_clients_in_current_round": set(),  # Set di client rotti nel round corrente
-    "gradient_flipping_history": {},  # Storico dei client che hanno applicato gradient flipping
-}
+def create_attack_config() -> AttackConfig:
+    """Return a fresh :class:`AttackConfig` instance."""
+    return AttackConfig()

--- a/core/client.py
+++ b/core/client.py
@@ -19,11 +19,21 @@ from models import Net, CNNNet, TinyMNIST, MinimalCNN, MiniResNet20, get_transfo
 
 # Importazione delle funzioni di attacco e configurazione
 import utilities.fl_attacks
-from configuration.attack_config import *
+from configuration.attack_config import create_attack_config
 from configuration.config_manager import get_config_manager
 import random
 import numpy as np
 from sklearn.metrics import precision_score, recall_score, f1_score
+
+# Load a fresh copy of attack configuration for each client
+attack_cfg = create_attack_config()
+ENABLE_ATTACKS = attack_cfg.enable_attacks
+NOISE_INJECTION = attack_cfg.noise_injection
+MISSED_CLASS = attack_cfg.missed_class
+CLIENT_FAILURE = attack_cfg.client_failure
+DATA_ASYMMETRY = attack_cfg.data_asymmetry
+LABEL_FLIPPING = attack_cfg.label_flipping
+GRADIENT_FLIPPING = attack_cfg.gradient_flipping
 
 # 1) definizione del modello locale
 # - I modelli sono ora importati dal modulo models.py


### PR DESCRIPTION
## Summary
- replace global attack dicts with `AttackConfig` dataclass
- update client and runner to use fresh copies via `create_attack_config`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'dasha')*

------
https://chatgpt.com/codex/tasks/task_e_684f6debd06c832a8f9af9c000075dcc