### PR TITLE
Fix server start wait using port check

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ Run federated learning with adversarial attacks:
 ```bash
 python experiment_runners/run_with_attacks.py --strategy fedavg --dataset cifar10 \
     --attack labelflip --labelflip-fraction 0.2 --num-clients 10
+# Optional: reduce wait time for server start (default 5s)
+python experiment_runners/run_with_attacks.py --strategy fedavg --dataset cifar10 \
+    --attack labelflip --labelflip-fraction 0.2 --num-clients 10 \
+    --server-start-timeout 2
 ```
 
 ### Setup and Verification


### PR DESCRIPTION
## Summary
- check port 8080 instead of sleeping in `run_with_attacks.py`
- allow configurable server startup timeout via `--server-start-timeout`
- document new option in README

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684fbb414504832a87dac94424cd284b