### PR TITLE
Handle stuck server in run_with_attacks

### DIFF
--- a/experiment_runners/run_with_attacks.py
+++ b/experiment_runners/run_with_attacks.py
@@ -78,6 +78,20 @@ except Exception as e:
     def create_attack_config() -> _FallbackConfig:  # type: ignore
         return _FallbackConfig()
 
+def terminate_process(proc: subprocess.Popen, timeout: int = 5) -> None:
+    """Terminate a subprocess gracefully, killing it if it ignores SIGTERM."""
+    proc.terminate()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        print(f"Process did not terminate in {timeout}s, killing...")
+        proc.kill()
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            pass
+
+
 def main():
     parser = argparse.ArgumentParser(description="Avvia esperimenti di FL con attacchi")
     parser.add_argument("--num-clients", type=int, default=10, help="Numero di client da avviare")
@@ -317,8 +331,7 @@ def main():
     
     # Termina il server
     print("Terminazione del server...")
-    server_process.terminate()
-    server_process.wait()
+    terminate_process(server_process)
     
     print("Esperimento completato")
 

--- a/tests/test_run_with_attacks_termination.py
+++ b/tests/test_run_with_attacks_termination.py
@@ -1,0 +1,31 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from experiment_runners.run_with_attacks import terminate_process
+
+class DummyProc:
+    def __init__(self):
+        self.killed = False
+    def terminate(self):
+        pass
+    def wait(self, timeout=None):
+        raise subprocess.TimeoutExpired(cmd="dummy", timeout=timeout)
+    def kill(self):
+        self.killed = True
+
+class DummyProcKillSuccess(DummyProc):
+    def wait(self, timeout=None):
+        if self.killed:
+            return 0
+        else:
+            raise subprocess.TimeoutExpired(cmd="dummy", timeout=timeout)
+
+
+def test_terminate_process_kills_after_timeout(monkeypatch):
+    proc = DummyProcKillSuccess()
+    terminate_process(proc, timeout=0)
+    assert proc.killed


### PR DESCRIPTION
## Summary
- add `terminate_process` helper to gracefully kill server
- use the helper in `run_with_attacks.py`
- add test to ensure server is killed after timeout

## Testing
- `pytest -q tests/test_run_with_attacks_termination.py`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684fbb5901e8832a87fc122cff58cb5d