### PR TITLE
Fix empty dataset division in LoggingClient

### DIFF
--- a/core/client.py
+++ b/core/client.py
@@ -249,11 +249,21 @@ class LoggingClient(fl.client.NumPyClient):
                 print(f"[Client {self.cid}] Batch {batch_idx}/{len(self.trainloader)} | "
                       f"loss={(total_loss/total):.4f}, acc={(correct/total):.4f}")
 
-        avg_loss = total_loss / total
-        accuracy = correct / total
-        precision = precision_score(y_true, y_pred, average="macro", zero_division=0)
-        recall = recall_score(y_true, y_pred, average="macro", zero_division=0)
-        f1 = f1_score(y_true, y_pred, average="macro", zero_division=0)
+        if total > 0:
+            avg_loss = total_loss / total
+            accuracy = correct / total
+            precision = precision_score(
+                y_true, y_pred, average="macro", zero_division=0
+            )
+            recall = recall_score(
+                y_true, y_pred, average="macro", zero_division=0
+            )
+            f1 = f1_score(y_true, y_pred, average="macro", zero_division=0)
+        else:
+            print(
+                f"[Client {self.cid}] No training data available, returning null metrics"
+            )
+            avg_loss = accuracy = precision = recall = f1 = 0.0
         print(
             f"[Client {self.cid}] fit complete | avg_loss={avg_loss:.4f}, accuracy={accuracy:.4f}, "
             f"precision={precision:.4f}, recall={recall:.4f}, f1={f1:.4f}"
@@ -311,11 +321,21 @@ class LoggingClient(fl.client.NumPyClient):
                     print(f"[Client {self.cid}] Eval batch {batch_idx}/{len(self.testloader)} | "
                           f"loss={(total_loss/total):.4f}, acc={(correct/total):.4f}")
 
-        avg_loss = total_loss / total
-        accuracy = correct / total
-        precision = precision_score(y_true, y_pred, average="macro", zero_division=0)
-        recall = recall_score(y_true, y_pred, average="macro", zero_division=0)
-        f1 = f1_score(y_true, y_pred, average="macro", zero_division=0)
+        if total > 0:
+            avg_loss = total_loss / total
+            accuracy = correct / total
+            precision = precision_score(
+                y_true, y_pred, average="macro", zero_division=0
+            )
+            recall = recall_score(
+                y_true, y_pred, average="macro", zero_division=0
+            )
+            f1 = f1_score(y_true, y_pred, average="macro", zero_division=0)
+        else:
+            print(
+                f"[Client {self.cid}] No evaluation data available, returning null metrics"
+            )
+            avg_loss = accuracy = precision = recall = f1 = 0.0
         print(
             f"[Client {self.cid}] evaluate complete | avg_loss={avg_loss:.4f}, accuracy={accuracy:.4f}, "
             f"precision={precision:.4f}, recall={recall:.4f}, f1={f1:.4f}"

--- a/tests/test_client_empty_dataset.py
+++ b/tests/test_client_empty_dataset.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+import torch
+from torch.utils.data import Dataset, DataLoader
+import types
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from core.client import LoggingClient
+
+class EmptyDataset(Dataset):
+    def __len__(self):
+        return 0
+    def __getitem__(self, idx):
+        raise IndexError
+
+def test_fit_and_evaluate_with_empty_dataset(monkeypatch):
+    empty_loader = DataLoader(EmptyDataset(), batch_size=32)
+
+    def fake_load_data(*args, **kwargs):
+        return empty_loader, empty_loader
+
+    monkeypatch.setattr(
+        sys.modules['core.client'], 'load_data', fake_load_data
+    )
+
+    client = LoggingClient(cid="0", num_clients=1, dataset_name="MNIST")
+    params = client.get_parameters({})
+
+    upd_params, total_fit, metrics_fit = client.fit(params, {})
+    assert total_fit == 0
+    assert metrics_fit["loss"] == 0.0
+    assert metrics_fit["accuracy"] == 0.0
+
+    loss, total_eval, metrics_eval = client.evaluate(params, {})
+    assert total_eval == 0
+    assert metrics_eval["loss"] == 0.0
+    assert metrics_eval["accuracy"] == 0.0


### PR DESCRIPTION
## Summary
- handle empty training and evaluation datasets
- add regression test to ensure empty datasets don't raise errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dasha')*

------
https://chatgpt.com/codex/tasks/task_e_684fbb830fc0832ab1e31a0b21139a27