### PR TITLE
Validate flipping attack parameters

### DIFF
--- a/attacks/gradient_flipping.py
+++ b/attacks/gradient_flipping.py
@@ -7,6 +7,8 @@ dei client malevoli per sabotare l'apprendimento federato.
 
 import numpy as np
 
+MAX_FLIP_INTENSITY = 10.0
+
 
 def select_clients_for_gradient_flipping(num_clients, gradient_flipping_fraction):
     """
@@ -19,7 +21,9 @@ def select_clients_for_gradient_flipping(num_clients, gradient_flipping_fraction
     Returns:
         list: Lista degli indici dei client da attaccare
     """
-    if gradient_flipping_fraction <= 0.0:
+    if not 0.0 <= gradient_flipping_fraction <= 1.0:
+        raise ValueError("gradient_flipping_fraction must be between 0 and 1")
+    if gradient_flipping_fraction == 0.0:
         return []
     
     num_attacked = max(1, int(gradient_flipping_fraction * num_clients))
@@ -41,7 +45,11 @@ def apply_gradient_flipping(model_parameters, flip_intensity=1.0):
     Returns:
         list: Parametri del modello con gradient flipping applicato
     """
-    if flip_intensity <= 0.0:
+    if flip_intensity < 0.0 or flip_intensity > MAX_FLIP_INTENSITY:
+        raise ValueError(
+            f"flip_intensity must be between 0 and {MAX_FLIP_INTENSITY}"
+        )
+    if flip_intensity == 0.0:
         return model_parameters
     
     flipped_parameters = []

--- a/attacks/label_flipping.py
+++ b/attacks/label_flipping.py
@@ -73,6 +73,9 @@ def apply_targeted_label_flipping(dataset, client_indices, source_class, target_
         tuple: (modified_dataset, num_flipped) dove modified_dataset è il dataset modificato
                e num_flipped è il numero di etichette modificate
     """
+    if not 0.0 <= flip_probability <= 1.0:
+        raise ValueError("flip_probability must be between 0 and 1")
+
     # Crea una copia del dataset per non modificare l'originale
     modified_targets = dataset.targets.clone() if isinstance(dataset.targets, torch.Tensor) else dataset.targets.copy()
     

--- a/tests/test_attack_validations.py
+++ b/tests/test_attack_validations.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+import numpy as np
+import torch
+from torch.utils.data import TensorDataset
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from attacks.label_flipping import apply_targeted_label_flipping
+from attacks.gradient_flipping import (
+    apply_gradient_flipping,
+    select_clients_for_gradient_flipping,
+    MAX_FLIP_INTENSITY,
+)
+
+
+class DummyDataset(TensorDataset):
+    def __init__(self):
+        data = torch.zeros(10, 1)
+        targets = torch.tensor([0, 1] * 5)
+        super().__init__(data, targets)
+        self.data = data
+        self.targets = targets
+
+
+def test_apply_targeted_label_flipping_invalid_probability():
+    ds = DummyDataset()
+    indices = list(range(len(ds)))
+    with pytest.raises(ValueError):
+        apply_targeted_label_flipping(ds, indices, 0, 1, -0.1)
+    with pytest.raises(ValueError):
+        apply_targeted_label_flipping(ds, indices, 0, 1, 1.1)
+
+
+def test_gradient_flipping_invalid_fraction():
+    with pytest.raises(ValueError):
+        select_clients_for_gradient_flipping(5, -0.2)
+    with pytest.raises(ValueError):
+        select_clients_for_gradient_flipping(5, 1.2)
+
+
+def test_apply_gradient_flipping_invalid_intensity():
+    params = [np.array([1.0, -1.0])]
+    with pytest.raises(ValueError):
+        apply_gradient_flipping(params, -0.1)
+    with pytest.raises(ValueError):
+        apply_gradient_flipping(params, MAX_FLIP_INTENSITY + 1)


### PR DESCRIPTION
## Summary
- check `flip_probability` range in `apply_targeted_label_flipping`
- validate gradient flipping fraction and intensity
- add tests covering invalid parameters

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684fbc5050b8832aaaa2bafdb3e3b1c4