### PR TITLE
Fix kill_flower_processes when process name is None

### DIFF
--- a/experiment_runners/enhanced_experiment_runner.py
+++ b/experiment_runners/enhanced_experiment_runner.py
@@ -549,7 +549,8 @@ class EnhancedExperimentRunner:
             killed_processes = []
             for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
                 try:
-                    if 'python' in proc.info['name'].lower():
+                    name = proc.info.get('name')
+                    if name and 'python' in name.lower():
                         cmdline = ' '.join(proc.info['cmdline'] or [])
                         if any(keyword in cmdline.lower() for keyword in 
                                ['flower', 'server.py', 'client.py', 'run_with_attacks.py']):

--- a/tests/test_kill_flower_none_name.py
+++ b/tests/test_kill_flower_none_name.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import psutil
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from experiment_runners.enhanced_experiment_runner import EnhancedExperimentRunner, EnhancedConfigManager
+
+class DummyPortManager:
+    def is_port_free(self, port):
+        return True
+
+class DummyProcess:
+    def __init__(self, pid=1, name=None, cmdline=None):
+        self.info = {'pid': pid, 'name': name, 'cmdline': cmdline or []}
+        self.terminated = False
+    def terminate(self):
+        self.terminated = True
+    def is_running(self):
+        return False
+    def kill(self):
+        pass
+
+def test_kill_flower_processes_handles_none_name(monkeypatch):
+    cfg_manager = EnhancedConfigManager(Path('configuration/enhanced_config.yaml'))
+    runner = EnhancedExperimentRunner(config_manager=cfg_manager, _test_mode=True)
+    runner.port_manager = DummyPortManager()
+
+    processes = [
+        DummyProcess(pid=1, name=None, cmdline=['python', 'server.py']),
+        DummyProcess(pid=2, name='python', cmdline=['run_with_attacks.py'])
+    ]
+
+    monkeypatch.setattr(psutil, 'process_iter', lambda attrs: processes)
+    runner.kill_flower_processes()
+    assert processes[1].terminated


### PR DESCRIPTION
## Summary
- avoid AttributeError in `kill_flower_processes` when `proc.info['name']` is `None`
- add regression test for `kill_flower_processes` handling of missing process name

## Testing
- `pytest tests/test_kill_flower_none_name.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: dasha, flwr_baselines)*

------
https://chatgpt.com/codex/tasks/task_e_684fbccaae98832a86217a65c3e480f6