### PR TITLE
Fix server port configuration

### DIFF
--- a/core/server.py
+++ b/core/server.py
@@ -12,6 +12,7 @@ sys.path.insert(0, str(parent_dir))
 
 from models import Net, CNNNet, TinyMNIST, MinimalCNN, MiniResNet20  # Importazione dei modelli dal modulo condiviso
 from core.strategies import create_strategy  # Importa il factory per le strategie
+from configuration.config_manager import get_config_manager
 import argparse
 
 # Funzioni per contare i parametri del modello
@@ -44,10 +45,13 @@ initial_parameters = ndarrays_to_parameters(initial_weights)
 # main
 if __name__ == "__main__":    # Parse command line arguments
     parser = argparse.ArgumentParser(description="Avvia il server di Federated Learning")
+    config_mgr = get_config_manager()
     parser.add_argument("--rounds", type=int, default=3, help="Numero di round di federazione da eseguire")
-    parser.add_argument("--dataset", type=str, default="MNIST", 
+    parser.add_argument("--dataset", type=str, default="MNIST",
                         choices=["MNIST", "FMNIST", "CIFAR10"],
                         help="Dataset da utilizzare (MNIST, FMNIST, CIFAR10)")
+    parser.add_argument("--port", type=int, default=config_mgr.system.port,
+                        help="Porta di ascolto del server")
     parser.add_argument(
         "--strategy", 
         type=str, 
@@ -186,7 +190,7 @@ if __name__ == "__main__":    # Parse command line arguments
     )
     
     fl.server.start_server(
-        server_address="0.0.0.0:8080",
+        server_address=f"0.0.0.0:{args.port}",
         config=fl.server.ServerConfig(num_rounds=args.rounds),
         strategy=strategy,
     )

--- a/tests/test_server_port.py
+++ b/tests/test_server_port.py
@@ -1,0 +1,23 @@
+import sys
+import runpy
+from pathlib import Path
+
+import flwr as fl
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_server_uses_cli_port(monkeypatch):
+    captured = {}
+
+    def fake_start_server(server_address, config=None, strategy=None):
+        captured["addr"] = server_address
+
+    monkeypatch.setattr(fl.server, "start_server", fake_start_server)
+    monkeypatch.setattr("core.server.create_strategy", lambda *a, **k: None)
+    testargs = ["server.py", "--rounds", "1", "--port", "9091"]
+    monkeypatch.setattr(sys, "argv", testargs)
+    runpy.run_module("core.server", run_name="__main__")
+    assert captured["addr"] == "0.0.0.0:9091"


### PR DESCRIPTION
## Summary
- make Flower server port configurable via `--port` option
- test that server uses CLI port

## Testing
- `pytest -q tests/test_server_port.py -s`
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684fbcf64008832aa4a1992589acbc42