### PR TITLE
Add validation for data asymmetry factors

### DIFF
--- a/attacks/data_asymmetry.py
+++ b/attacks/data_asymmetry.py
@@ -23,6 +23,12 @@ def generate_client_sizes(total_data, num_clients, min_factor, max_factor):
     Returns:
         list: Lista delle dimensioni dei dataset per ogni client
     """
+    if min_factor <= 0:
+        raise ValueError("min_factor must be > 0")
+    if max_factor <= 0:
+        raise ValueError("max_factor must be > 0")
+    if min_factor > max_factor:
+        raise ValueError("min_factor must be <= max_factor")
     # Se min_factor = max_factor, distribuisci i dati in modo uniforme
     if min_factor == max_factor:
         base_size = total_data // num_clients

--- a/tests/test_data_asymmetry.py
+++ b/tests/test_data_asymmetry.py
@@ -2,6 +2,7 @@ import sys
 import numpy as np
 from pathlib import Path
 from torch.utils.data import Dataset
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -44,3 +45,22 @@ def test_create_asymmetric_datasets(tmp_path):
     assert len(dsets) == 3
     assert sum(len(d.indices) for d in dsets) <= len(dataset)
     assert set(removed.keys()) <= {0, 1, 2}
+
+
+def test_generate_client_sizes_invalid_min_factor():
+    with pytest.raises(ValueError):
+        generate_client_sizes(10, 2, 0, 1)
+    with pytest.raises(ValueError):
+        generate_client_sizes(10, 2, -0.5, 1)
+
+
+def test_generate_client_sizes_invalid_max_factor():
+    with pytest.raises(ValueError):
+        generate_client_sizes(10, 2, 1, 0)
+    with pytest.raises(ValueError):
+        generate_client_sizes(10, 2, 1, -2)
+
+
+def test_generate_client_sizes_min_greater_than_max():
+    with pytest.raises(ValueError):
+        generate_client_sizes(10, 2, 2, 1)


### PR DESCRIPTION
## Summary
- validate parameters for `generate_client_sizes`
- raise `ValueError` on invalid configuration
- test invalid inputs for data asymmetry

## Testing
- `pytest tests/test_data_asymmetry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684ff09e1008832aa5e4ae3efe776289