### PR TITLE
Add validation for data asymmetry factors

### DIFF
--- a/attacks/data_asymmetry.py
+++ b/attacks/data_asymmetry.py
@@ -13,16 +13,18 @@ from .missed_class import create_missed_class_dataset
 def generate_client_sizes(total_data, num_clients, min_factor, max_factor):
     """
     Genera le dimensioni dei dataset per i client in modo asimmetrico.
-    
+
     Args:
         total_data: Numero totale di dati da distribuire
         num_clients: Numero di client
         min_factor: Fattore minimo per la distribuzione uniforme
         max_factor: Fattore massimo per la distribuzione uniforme
-    
+
     Returns:
         list: Lista delle dimensioni dei dataset per ogni client
     """
+    if min_factor <= 0 or min_factor > max_factor:
+        raise ValueError("0 < min_factor <= max_factor must hold")
     # Se min_factor = max_factor, distribuisci i dati in modo uniforme
     if min_factor == max_factor:
         base_size = total_data // num_clients

--- a/tests/test_data_asymmetry.py
+++ b/tests/test_data_asymmetry.py
@@ -2,6 +2,7 @@ import sys
 import numpy as np
 from pathlib import Path
 from torch.utils.data import Dataset
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -34,6 +35,13 @@ def test_generate_client_sizes_zero_handling():
     assert sum(sizes) == 5
     assert len(sizes) == 10
     assert all(s in (0, 1) for s in sizes)
+
+
+def test_generate_client_sizes_invalid_range():
+    with pytest.raises(ValueError):
+        generate_client_sizes(10, 3, -0.5, 1.0)
+    with pytest.raises(ValueError):
+        generate_client_sizes(10, 3, 1.1, 1.0)
 
 
 def test_create_asymmetric_datasets(tmp_path):


### PR DESCRIPTION
## Summary
- validate `min_factor` and `max_factor` in data asymmetry attack
- test invalid parameters for `generate_client_sizes`

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff0f95cc8832abd322feab20c9afb