### PR TITLE
Ensure attack path inserted once

### DIFF
--- a/tests/test_fl_attacks_sys_path.py
+++ b/tests/test_fl_attacks_sys_path.py
@@ -1,0 +1,17 @@
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+
+def test_fl_attacks_path_not_duplicated():
+    import utilities.fl_attacks as fl_attacks
+    attack_path = str(ROOT / "attacks")
+    # Should be inserted exactly once after initial import
+    assert sys.path.count(attack_path) == 1
+
+    importlib.reload(fl_attacks)
+    # Path should still appear only once
+    assert sys.path.count(attack_path) == 1

--- a/utilities/fl_attacks.py
+++ b/utilities/fl_attacks.py
@@ -15,9 +15,11 @@ Gli attacchi sono stati spostati nella cartella attacks/ e organizzati in moduli
 import sys
 from pathlib import Path
 
-# Add path for attacks import
+# Add path for attacks import, avoiding duplicates in sys.path
 parent_dir = Path(__file__).parent.parent
-sys.path.insert(0, str(parent_dir / "attacks"))
+attack_path = str(parent_dir / "attacks")
+if attack_path not in sys.path:
+    sys.path.insert(0, attack_path)
 
 # Importa tutte le funzioni dai moduli degli attacchi per mantenere la compatibilità
 from attacks import *


### PR DESCRIPTION
## Summary
- avoid duplicate sys.path insertion in `fl_attacks`
- test importing utilities.fl_attacks twice

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dasha')*
- `pytest tests/test_fl_attacks_sys_path.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ff1009404832a9969067c250e195a