### PR TITLE
Remove unused pickle import

### DIFF
--- a/utilities/checkpoint_manager.py
+++ b/utilities/checkpoint_manager.py
@@ -6,7 +6,6 @@ l'esecuzione in caso di interruzioni.
 """
 
 import json
-import pickle
 import logging
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Set


### PR DESCRIPTION
## Summary
- remove unused `pickle` import from checkpoint manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dasha')*

------
https://chatgpt.com/codex/tasks/task_e_684ff16376fc832ab6716ea9c632a3ad