### PR TITLE
Fix logger warning formatting

### DIFF
--- a/experiment_runners/enhanced_experiment_runner.py
+++ b/experiment_runners/enhanced_experiment_runner.py
@@ -632,7 +632,8 @@ class EnhancedExperimentRunner:
                             proc.kill()
                         except (ValueError, psutil.NoSuchProcess, psutil.AccessDenied):
                             continue
-        except Exception as e:            logger.warning(f"Error killing processes using port {port}: {e}")
+        except Exception as e:
+            logger.warning(f"Error killing processes using port {port}: {e}")
             
     def wait_for_port(self, port: int, timeout: int = 60):
         """Attende che una porta diventi libera."""


### PR DESCRIPTION
## Summary
- fix formatting of logger warning in exception block

## Testing
- `pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_684ff17e2848832aa0a2bd7cdd28ff0e